### PR TITLE
[12.0][ADD] erplibre sale email template base

### DIFF
--- a/erplibre_sale_email_template_base/__init__.py
+++ b/erplibre_sale_email_template_base/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/erplibre_sale_email_template_base/__manifest__.py
+++ b/erplibre_sale_email_template_base/__manifest__.py
@@ -1,0 +1,19 @@
+
+{
+    'name': 'ERPLibre Sale Email Template Base',
+    'author': 'TechnoLibre',
+    'website': 'https://technolibre.ca',
+    'category': 'Other',
+    'description': 'Base module for email template. Exposing the color variables for template styling',
+    'depends': [
+        'mail',
+        'sale',
+
+        # Muk
+        'muk_web_theme',
+    ],
+    'data': [
+        'data/mail_data.xml',
+    ],
+    "auto_install": False,
+}

--- a/erplibre_sale_email_template_base/data/mail_data.xml
+++ b/erplibre_sale_email_template_base/data/mail_data.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <data>
+    <template id="mail_notification_paynow_custom" name="Mail: Pay Now mail notification template - custom" inherit_id="mail.mail_notification_paynow">
+
+      <!-- get the color from sale.order modal -->
+      <xpath expr="//tbody" position="before">
+        <t t-set="primary_color" t-value="record.get_theme_color()"/>
+      </xpath>
+
+      <!-- link button color to theme colors -->
+      <xpath expr="//tbody/tr[2]/td/div[1]/a" position="attributes">
+        <attribute name="style"></attribute>
+        <attribute name="t-att-style">'background-color: ' + primary_color + '; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;'</attribute>
+      </xpath>
+
+    </template>
+
+  </data>
+</odoo>

--- a/erplibre_sale_email_template_base/models/__init__.py
+++ b/erplibre_sale_email_template_base/models/__init__.py
@@ -1,0 +1,5 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import (
+    sale_order,
+)

--- a/erplibre_sale_email_template_base/models/sale_order.py
+++ b/erplibre_sale_email_template_base/models/sale_order.py
@@ -1,0 +1,35 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+XML_ID = "muk_web_theme._assets_primary_variables"
+SCSS_URL = "/muk_web_theme/static/src/scss/colors.scss"
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.model
+    def get_theme_color(self, field_name='theme_color_primary'):
+        variables = [
+            'o-brand-odoo',
+            'o-brand-primary',
+            'mk-required-color',
+            'mk-apps-color',
+            'mk-appbar-color',
+            'mk-appbar-background',
+        ]
+
+        colors = self.env['muk_utils.scss_editor'].get_values(
+            SCSS_URL, XML_ID, variables
+        )
+
+        dict_colors = {
+            'theme_color_brand': colors['o-brand-odoo'],
+            'theme_color_primary': colors['o-brand-primary'],
+            'theme_color_required': colors['mk-required-color'],
+            'theme_color_menu': colors['mk-apps-color'],
+            'theme_color_appbar_color': colors['mk-appbar-color'],
+            'theme_color_appbar_background': colors['mk-appbar-background'],
+        }
+
+        return dict_colors.get(field_name, '#5D8DA8')


### PR DESCRIPTION
- exposing theme colors to style elements in templates
- link theme primary color to button background color in mail_notification_paynow sale template

- TODO: explore expanding this to other templates to align branding.  
